### PR TITLE
remove extra 'fsl' from bashrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV FSLDIR="/opt/fsl" \
     FSLOUTPUTTYPE=NIFTI_GZ \
     PATH="/opt/fsl/bin:$PATH"
 
-RUN curl -sL https://fsl.fmrib.ox.ac.uk/fsldownloads/fslinstaller.py -o fslinstaller.py && python3 fslinstaller.py -d /usr/local/fsl -o && echo ". /usr/local/fsl/fsl/etc/fslconf/fsl.sh" >> ~/.bashrc
+RUN curl -sL https://fsl.fmrib.ox.ac.uk/fsldownloads/fslinstaller.py -o fslinstaller.py && python3 fslinstaller.py -d /usr/local/fsl -o && echo ". /usr/local/fsl/etc/fslconf/fsl.sh" >> ~/.bashrc
 
 # Install Freesurfer
 ENV FREESURFER_HOME="/opt/freesurfer" \


### PR DESCRIPTION
Fixed small typo I noticed using your petprep_hmc as a base file for our defacing pipeline.

Fixes the following error:
```bash
(petdeface-py3.10) galassiae@MH02276145MLI petdeface % docker run -it --rm petdeface /bin/bash
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
bash: /usr/local/fsl/fsl/etc/fslconf/fsl.sh: No such file or directory
``` 