### PR TITLE
Replace absolute to relative paths in html report

### DIFF
--- a/run.py
+++ b/run.py
@@ -525,7 +525,7 @@ def display_motion_correction_html(file_prefix, sub_out_dir):
             caption = f"<p>{reportlet.get('caption', '')}</p>"
 
             # Generate HTML image tag or use plotly for GIFs if needed
-            img_tag = f"<img src='{file_path}' style='width:100%; max-width:{reportlet['style']['max-width']}'>"
+            img_tag = f"<img src='{file_name}' style='width:100%; max-width:{reportlet['style']['max-width']}'>"
 
             # Combine elements
             html_content += title + caption + img_tag + "<br>"


### PR DESCRIPTION
I replaced the absolute pathing in the html report to relative paths.

Previously, the reports would stop working when the folders were moved, or when they were generated using WSL and opened using Windows. This corrects that bug by using relative pathing.