### PR TITLE
Add group level results

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To run the PETPrep Head Motion Correction BIDS App, use the following command:
 
 - `bids_dir`: Path to the input BIDS dataset
 - `output_dir`: Path to the output directory for preprocessed data
-- `analysis_level`: Level of the analysis that will be performed. Multiple participant level analyses can be run independently (in parallel) using the same output_dir.
+- `analysis_level`: Level of the analysis that will be performed. Set to `participant` (default) to process each subject independently. After all participants have been run, set `analysis_level=group` to collate the motion estimates and generate a summary report (`group_report.html` and accompanying plot) in the root of `output_dir`.
 - `--participant_label`: (Optional) A single participant label or a space-separated list of participant labels to process (e.g. sub-01 sub02). If not provided, all participants in the dataset will be processed.
 - `--participant_label_exclude`: (Optional) A single participant label or a space-separated list of participant labels to exclude in the processing (e.g. sub-01 sub02). If not provided, all participants in the dataset will be processed.
 - `--session_label`: (Optional) A single session label or a space-separated list of session labels to process (e.g. ses-01 ses-02). If not provided, all sessions in the dataset will 
@@ -70,6 +70,8 @@ For example, to process participant `sub-01`, use the following command:
 ## Outputs
 
 Preprocessed PET data along with the estimated motion parameters (confounds) and motion plots will be stored in the directory specified by the second command line argument. If no output directory is specified the outputs will saved to `<bids_dir>/derivatives/petprep_hmc` with `<bids_dir>` corresponding to the first command line argument.
+
+When running with `analysis_level=group`, a combined summary plot and HTML report (`group_report.html`) are generated in the root of the chosen output directory alongside `dataset_description.json`.
 
 ## Installation and Running the Code using Docker
 

--- a/run.py
+++ b/run.py
@@ -791,7 +791,9 @@ def run_group_level(args):
     else:
         derivatives_dir = args.output_dir
 
-    pattern = os.path.join(derivatives_dir, "sub-*", "**", "*_desc-confounds_timeseries.tsv")
+    pattern = os.path.join(
+        derivatives_dir, "sub-*", "**", "*_desc-confounds_timeseries.tsv"
+    )
     confound_files = glob.glob(pattern, recursive=True)
     confound_files = sorted(confound_files)
 
@@ -814,13 +816,15 @@ def run_group_level(args):
 
     combined = pd.concat(data_frames, ignore_index=True)
     metrics = [c for c in combined.columns if c not in ["source"]]
-    stats = pd.DataFrame({
-        "mean": combined[metrics].mean(),
-        "std": combined[metrics].std(),
-        "range": combined[metrics].max() - combined[metrics].min(),
-        "min": combined[metrics].min(),
-        "max": combined[metrics].max()
-    })
+    stats = pd.DataFrame(
+        {
+            "mean": combined[metrics].mean(),
+            "std": combined[metrics].std(),
+            "range": combined[metrics].max() - combined[metrics].min(),
+            "min": combined[metrics].min(),
+            "max": combined[metrics].max(),
+        }
+    )
 
     plot_path = os.path.join(derivatives_dir, "group_median_tot_plot.png")
     sns.histplot(combined["median_tot"], bins=30)
@@ -835,7 +839,9 @@ def run_group_level(args):
         f.write("<h2>Summary statistics</h2>")
         f.write(stats.to_html())
         f.write("<h2>Median movement distribution</h2>")
-        f.write(f"<img src='{os.path.basename(plot_path)}' alt='group median_tot plot'>")
+        f.write(
+            f"<img src='{os.path.basename(plot_path)}' alt='group median_tot plot'>"
+        )
         if high_motion:
             f.write("<h2>Runs with median_tot > 5 mm</h2><ul>")
             for item in high_motion:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,3 +15,17 @@ def test_cli():
         cmd = f"python3 run.py --bids_dir {bids_dir} --output_dir {output_dir}"
         exit_code = subprocess.call(cmd, shell=True)
         assert exit_code == 0
+
+
+def test_cli_group_level():
+    repo_root = Path(__file__).parent.parent.resolve()
+    bids_dir = repo_root / "data"
+    output_dir = bids_dir / "derivatives"
+
+    cmd = (
+        f"python3 run.py --bids_dir {bids_dir} --output_dir {output_dir} "
+        f"--analysis_level group"
+    )
+    exit_code = subprocess.call(cmd, shell=True)
+    assert exit_code == 0
+    assert (output_dir / "group_report.html").exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,3 +29,28 @@ def test_cli_group_level():
     exit_code = subprocess.call(cmd, shell=True)
     assert exit_code == 0
     assert (output_dir / "group_report.html").exists()
+
+
+def test_cli_group_high_motion():
+    repo_root = Path(__file__).parent.parent.resolve()
+    bids_dir = repo_root / "data"
+
+    with tempfile.TemporaryDirectory() as tmp_output_dir:
+        derivatives = Path(tmp_output_dir) / "derivatives" / "petprep_hmc" / "sub-01"
+        derivatives.mkdir(parents=True, exist_ok=True)
+
+        confounds_tsv = derivatives / "sub-01_desc-confounds_timeseries.tsv"
+        confounds_tsv.write_text("median_tot\n6\n7\n")
+
+        cmd = (
+            f"python3 run.py {bids_dir} {Path(tmp_output_dir) / 'derivatives'} group"
+        )
+        exit_code = subprocess.call(cmd, shell=True)
+        assert exit_code == 0
+
+        report_file = Path(tmp_output_dir) / "derivatives" / "group_report.html"
+        plot_file = Path(tmp_output_dir) / "derivatives" / "group_motion.png"
+        assert report_file.exists()
+        assert plot_file.exists()
+        html = report_file.read_text()
+        assert "sub-01" in html

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,9 +42,7 @@ def test_cli_group_high_motion():
         confounds_tsv = derivatives / "sub-01_desc-confounds_timeseries.tsv"
         confounds_tsv.write_text("median_tot\n6\n7\n")
 
-        cmd = (
-            f"python3 run.py {bids_dir} {Path(tmp_output_dir) / 'derivatives'} group"
-        )
+        cmd = f"python3 run.py {bids_dir} {Path(tmp_output_dir) / 'derivatives'} group"
         exit_code = subprocess.call(cmd, shell=True)
         assert exit_code == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ def test_cli():
         cmd = f"python3 run.py --bids_dir {bids_dir} --output_dir {output_dir}"
         exit_code = subprocess.call(cmd, shell=True)
         assert exit_code == 0
-        
+
         json_files = list(output_dir.rglob("*desc-mc_pet.json"))
         assert json_files, "No output JSON files found"
         with open(json_files[0]) as jf:


### PR DESCRIPTION
This PR closes issue #38 by adding the feature to run group level analyses, summarizing the detected motion estimates across scans. 