### PR TITLE
ENH: Add ITK transform file generation and reference image outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ For example, to process participant `sub-01`, use the following command:
 ## Outputs
 
 Preprocessed PET data along with the estimated motion parameters (confounds) and motion plots will be stored in the directory specified by the second command line argument. If no output directory is specified the outputs will saved to `<bids_dir>/derivatives/petprep_hmc` with `<bids_dir>` corresponding to the first command line argument.
+Additionally, a text file containing all framewise transforms in ITK format will be saved for each run with the suffix `_from-orig_to-petref_mode-image_xfm.txt`. Each processed run also includes an unbiased PET reference image derived during motion estimation. This reference is saved as `*_desc-hmc_petref.nii.gz` in the derivatives directory.
 
 ## Installation and Running the Code using Docker
 

--- a/run.py
+++ b/run.py
@@ -317,7 +317,6 @@ def main(args):
 
 
 def init_petprep_hmc_wf(subjects, sessions_to_exclude=[]):
-
     petprep_hmc_wf = Workflow(name="petprep_hmc_wf", base_dir=args.bids_dir)
     petprep_hmc_wf.config["execution"]["remove_unnecessary_outputs"] = "false"
 
@@ -728,7 +727,6 @@ def combine_hmc_outputs(translations, rot_angles, rotation_translation_matrix, i
 
     movement = []
     for idx, trans in enumerate(translations):
-
         img = nib.load(in_file[idx])
         vox_ind = np.asarray(np.nonzero(img.get_fdata()))
         pos_bef = np.concatenate((vox_ind, np.ones((1, len(vox_ind[0, :])))))

--- a/run.py
+++ b/run.py
@@ -156,6 +156,16 @@ def main(args):
             Path(args.bids_dir), "petprep_hmc_wf", "*", "*", "*", "translation.png"
         )
     )
+    itk_files = glob.glob(
+        os.path.join(
+            Path(args.bids_dir), "petprep_hmc_wf", "*", "*", "*", "itk_transforms.txt"
+        )
+    )
+    petref_files = glob.glob(
+        os.path.join(
+            Path(args.bids_dir), "petprep_hmc_wf", "*", "*", "*", "hmc_petref.nii.gz"
+        )
+    )
 
     for idx, x in enumerate(mc_files):
         match_sub_id = re.search(r"sub-([A-Za-z0-9]+)_", mc_files[idx])
@@ -203,6 +213,17 @@ def main(args):
         shutil.copyfile(
             translation[idx],
             os.path.join(sub_out_dir, f"{file_prefix}_desc-translation.png"),
+        )
+        shutil.copyfile(
+            itk_files[idx],
+            os.path.join(
+                sub_out_dir,
+                f"{file_prefix}_from-orig_to-petref_mode-image_xfm.txt",
+            ),
+        )
+        shutil.copyfile(
+            petref_files[idx],
+            os.path.join(sub_out_dir, f"{file_prefix}_desc-hmc_petref.nii.gz"),
         )
 
         if ses_id is not None and run_id is None:
@@ -387,6 +408,12 @@ def init_single_subject_wf(subject_id, sessions_to_exclude=[]):
         iterfield=["in_files"],
     )
 
+    # Convert the template from mri_robust_register to NIfTI for export
+    convert_petref = Node(
+        fs.MRIConvert(out_type="niigz", out_file="hmc_petref.nii.gz"),
+        name="convert_petref",
+    )
+
     correct_motion = MapNode(
         interface=fs.ApplyVolTransform(),
         name="correct_motion",
@@ -460,6 +487,16 @@ def init_single_subject_wf(subject_id, sessions_to_exclude=[]):
         name="plot_motion",
     )
 
+    mat_to_itk = Node(
+        Function(
+            input_names=["mat_list", "out_file"],
+            output_names=["out_file"],
+            function=write_itk_transforms,
+        ),
+        name="mat_to_itk",
+    )
+    mat_to_itk.inputs.out_file = "itk_transforms.txt"
+
     # Connect workflow - init_pet_hmc_wf
     subject_wf.connect(
         [
@@ -478,6 +515,7 @@ def init_single_subject_wf(subject_id, sessions_to_exclude=[]):
                 estimate_motion,
                 [("upd_list_transforms", "transform_outputs")],
             ),
+            (estimate_motion, convert_petref, [("out_file", "in_file")]),
             (split_pet, correct_motion, [("out_file", "source_file")]),
             (estimate_motion, correct_motion, [("transform_outputs", "reg_file")]),
             (estimate_motion, correct_motion, [("out_file", "target_file")]),
@@ -490,6 +528,7 @@ def init_single_subject_wf(subject_id, sessions_to_exclude=[]):
             (estimate_motion, lta2xform, [("transform_outputs", "in_lta")]),
             (estimate_motion, lta2xform, [(("transform_outputs", lta2mat), "out_fsl")]),
             (lta2xform, est_trans_rot, [("out_fsl", "mat_file")]),
+            (lta2xform, mat_to_itk, [("out_fsl", "mat_list")]),
             (
                 est_trans_rot,
                 hmc_movement_output,
@@ -626,6 +665,22 @@ def lta2mat(in_file):
 
     mat_list = [ext.replace(".lta", ".mat") for ext in in_file]
     return mat_list
+
+
+def write_itk_transforms(mat_list, out_file):
+    """Write ITK transform file from a list of FSL matrices."""
+    import numpy as np
+
+    with open(out_file, "w") as f:
+        f.write("#Insight Transform File V1.0\n")
+        for idx, mat in enumerate(mat_list):
+            matrix = np.loadtxt(mat)
+            params = list(matrix[:3, :3].ravel()) + list(matrix[:3, 3])
+            f.write(f"#Transform {idx}\n")
+            f.write("Transform: AffineTransform_float_3_3\n")
+            f.write("Parameters: " + " ".join(str(v) for v in params) + "\n")
+            f.write("FixedParameters: 0 0 0\n\n")
+    return out_file
 
 
 def get_min_frame(json_file, mc_start_time):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,3 +27,9 @@ def test_cli():
             # ensure QC report path stored and file exists
             assert "QC" in data
             assert os.path.exists(data["QC"])
+        
+        txt_files = list(output_dir.rglob("*_xfm.txt"))
+        assert txt_files, "No transform text files found"
+
+        petref_files = list(output_dir.rglob("*_desc-hmc_petref.nii.gz"))
+        assert petref_files, "No reference image found"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,7 @@ def test_cli():
             # ensure QC report path stored and file exists
             assert "QC" in data
             assert os.path.exists(data["QC"])
-        
+
         txt_files = list(output_dir.rglob("*_xfm.txt"))
         assert txt_files, "No transform text files found"
 


### PR DESCRIPTION
This PR closes issue #41 by adding a ITK transform file for the estimated motion transforms, and also outputs the generated reference image from the mri_robust_template registration part. 